### PR TITLE
fix(stylelint-config-landr): leading zero

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # General Project Maintainers
-* @robertcoopercode benoitdeziel
+* @robertcoopercode @benoitdeziel

--- a/stylelint-config-landr/index.js
+++ b/stylelint-config-landr/index.js
@@ -21,7 +21,7 @@ module.exports = {
         "declaration-colon-space-after": "always",
         "property-no-vendor-prefix": true,
         "value-no-vendor-prefix": true,
-        "number-leading-zero": "never",
+        "number-leading-zero": "always",
         "function-name-case": null,
         "function-url-quotes": "always",
         "font-weight-notation": "numeric",

--- a/stylelint-config-landr/package.json
+++ b/stylelint-config-landr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-landr",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "Robert Cooper <rcooper@landr.com>",
   "description": "LANDR's shareable Stylelint configuration",
   "repository": {


### PR DESCRIPTION
## Description
We need to have leading zeros for numbers because prettier adds this automatically and there is [no way to turn that off in prettier](https://github.com/prettier/prettier/issues/2705).

BONUS: Fixed a typo in the CODEOWNERS file

## Checklist

-   [x] Updated the version number in the `package.json`