### PR TITLE
fix(prettier-config-landr): set tabWidth for json, scss, and html files

### DIFF
--- a/prettier-config-landr/index.js
+++ b/prettier-config-landr/index.js
@@ -17,10 +17,10 @@ module.exports = {
             }
         },
         {
-            "files": "*.{js,ts,jsx,tsx}",
+            "files": "*.{js,ts,jsx,tsx,scss,json,html}",
             "options": {
                 "tabWidth": 4,
             }
-        }
+        },
     ]
 }

--- a/prettier-config-landr/package.json
+++ b/prettier-config-landr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-landr",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "LANDR's shareable Prettier config",
   "main": "index.js",
   "repository": "https://github.com/Mixgenius/linting-and-formatting/tree/master/prettier-config-landr",


### PR DESCRIPTION
## Description
Tab width should be 4 spaces for JSON, SCSS, and HTML files as that is what is currently being used in our web app and Guest Site.

## Checklist

-   [x] Updated the version number in the `package.json`