### PR TITLE
feat(eslint-config-landr): add import/order rule

### DIFF
--- a/eslint-config-landr/index.js
+++ b/eslint-config-landr/index.js
@@ -19,7 +19,7 @@ module.exports = {
         ]
       }
     ],
-    strict: ["error", "global"],
+    "strict": ["error", "global"],
     "no-undef": "error",
     "spaced-comment": [
       "error",
@@ -31,7 +31,7 @@ module.exports = {
         }
       }
     ],
-    curly: "error",
+    "curly": "error",
     "eol-last": "error",
     "guard-for-in": "error",
     "no-labels": "error",
@@ -50,8 +50,9 @@ module.exports = {
     "no-var": "error",
     "brace-style": "error",
     "prefer-template": "error",
-    radix: "error",
+    "radix": "error",
     "space-before-blocks": "error",
+    "import/order": ["error", {"newlines-between": "never"}],
     "@typescript-eslint/no-use-before-define": "error",
     "@typescript-eslint/camelcase": [
       "error",

--- a/eslint-config-landr/package.json
+++ b/eslint-config-landr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-landr",
   "description": "LANDR's shareable ESLint config",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "index.js",
   "license": "MIT",
   "author": "Robert Cooper <rcooper@landr.com>",


### PR DESCRIPTION
## Description
This setting orders imports in a way that places external imports on top and relative imports afterwards. I've prevented the option of having spaces between import statements because I was getting some weird behaviour when permitting spaces between imports.

With this rule, we should no longer be asking people to manually re-order import statements in pull requests.

## Checklist

-   [x] Updated the version number in the `package.json`