### PR TITLE
fix(eslint-config-landr): add missing plugin to plugins array

### DIFF
--- a/eslint-config-landr/index.js
+++ b/eslint-config-landr/index.js
@@ -4,7 +4,7 @@ module.exports = {
         ecmaVersion: 2018,
         sourceType: 'module',
     },
-    plugins: ['@typescript-eslint'],
+    plugins: ['@typescript-eslint', 'import'],
     extends: [
         'plugin:prettier/recommended', // Enables eslint-plugin-prettier, displays prettier errors as ESLint errors, and extends eslint-config-prettier. Make sure this is always the last element of the extends array so that extended configs don't conflict with prettier.
     ],

--- a/eslint-config-landr/package.json
+++ b/eslint-config-landr/package.json
@@ -1,7 +1,7 @@
 {
     "name": "eslint-config-landr",
     "description": "LANDR's shareable ESLint config",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "main": "index.js",
     "license": "MIT",
     "author": "Robert Cooper <rcooper@landr.com>",


### PR DESCRIPTION
## Description
Forgot to add the `import` plugin to the `plugins` array of the ESLint config file 🤦‍♂️

## Checklist

-   [x] Updated the version number in the `package.json`