### PR TITLE
chore: update printWidth settings in prettier

### DIFF
--- a/prettier-config-landr/index.js
+++ b/prettier-config-landr/index.js
@@ -1,7 +1,7 @@
 module.exports = {
     singleQuote: true,
     semi: true,
-    printWidth: 100,
+    printWidth: 120,
     trailingComma: 'all',
     overrides: [
         {

--- a/prettier-config-landr/package.json
+++ b/prettier-config-landr/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-config-landr",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "LANDR's shareable Prettier config",
     "main": "index.js",
     "repository": "https://github.com/Mixgenius/linting-and-formatting/tree/master/prettier-config-landr",


### PR DESCRIPTION
## Description
100 characters is really short when using 4 spaces tabWidth.
https://hackernoon.com/does-column-width-of-80-make-sense-in-2018-50c161fbdcf6

before prettier i was using 140 characters but it will be nice to compromise at least to 120.

Let's open the discussion

100 char in blue - vs - vertical line (120)
![Screen Shot 2019-07-03 at 3 08 46 PM](https://user-images.githubusercontent.com/954888/60618562-7aaf0a80-9da4-11e9-9780-3b8218974b4c.png)


## Checklist
not done yet
- [x] Updated the version number in the `package.json`
- [x] Test any new configuration on a repo using [`npm link`](https://docs.npmjs.com/cli/link)
