### PR TITLE
chore: update readme with bump version rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ Monorepo to hold all shareable linting and formatting configurations.
 
 When using both ESLint and Prettier in a project, it's nice to have files automatically have ESLint errors fixed on save as well as have non JavaScript/TypeScript files formatted on save. This section explains how to set that up in an editor.
 
-### Versions Bump
-Patch releases: 
+### Versions Bump 
+#### Patch releases: 
   - Bump dependencies to patch or minor releases
-  - Fixs not impacting the configs or adding new rules
-Minor releases: 
+  - Fixes not impacting the configs or adding new rules
+#### Minor releases: 
   - Adding exceptions to rules (ex: disable a default rule)
-  - Changin Minor rules (Nothing that will reformat code by default)
-Major releases: 
+  - Changing linting rules (ex: `{ printWidth: 80 }` -> `{ printWidth: 120 }`)
+#### Major releases: 
+  - Breaking changes in repo
   - Bump dependencies to major releases
-  - Changing rules that will reformat code by default (ex: `{ printWidth: 80 }` -> `{ printWidth: 120 }`)
 
 ### VS Code
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Monorepo to hold all shareable linting and formatting configurations.
 
 When using both ESLint and Prettier in a project, it's nice to have files automatically have ESLint errors fixed on save as well as have non JavaScript/TypeScript files formatted on save. This section explains how to set that up in an editor.
 
-### Versions Bump 
-#### Patch releases: 
+### Semantic version Bump Rules
+#### Patch releases (1.0.x): 
   - Bump dependencies to patch or minor releases
   - Fixes not impacting the configs or adding new rules
-#### Minor releases: 
+#### Minor releases (1.X): 
   - Adding exceptions to rules (ex: disable a default rule)
   - Changing linting rules (ex: `{ printWidth: 80 }` -> `{ printWidth: 120 }`)
-#### Major releases: 
+#### Major releases(X): 
   - Breaking changes in repo
   - Bump dependencies to major releases
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ Monorepo to hold all shareable linting and formatting configurations.
 
 When using both ESLint and Prettier in a project, it's nice to have files automatically have ESLint errors fixed on save as well as have non JavaScript/TypeScript files formatted on save. This section explains how to set that up in an editor.
 
+### Versions Bump
+Patch releases: 
+  - Bump dependencies to patch or minor releases
+  - Fixs not impacting the configs or adding new rules
+Minor releases: 
+  - Adding exceptions to rules (ex: disable a default rule)
+  - Changin Minor rules (Nothing that will reformat code by default)
+Major releases: 
+  - Bump dependencies to major releases
+  - Changing rules that will reformat code by default (ex: `{ printWidth: 80 }` -> `{ printWidth: 120 }`)
+
 ### VS Code
 
 Make sure to have the [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) and [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) extensions installed.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Monorepo to hold all shareable linting and formatting configurations.
 When using both ESLint and Prettier in a project, it's nice to have files automatically have ESLint errors fixed on save as well as have non JavaScript/TypeScript files formatted on save. This section explains how to set that up in an editor.
 
 ### Semantic version increment rules
-#### Patch releases (1.0.x): 
+#### Patch releases (1.0.X): 
   - Bump dependencies to patch or minor releases
   - Fixes not impacting the configs or adding new rules
 #### Minor releases (1.X): 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Monorepo to hold all shareable linting and formatting configurations.
 
 When using both ESLint and Prettier in a project, it's nice to have files automatically have ESLint errors fixed on save as well as have non JavaScript/TypeScript files formatted on save. This section explains how to set that up in an editor.
 
-### Semantic version Bump Rules
+### Semantic version increment rules
 #### Patch releases (1.0.x): 
   - Bump dependencies to patch or minor releases
   - Fixes not impacting the configs or adding new rules


### PR DESCRIPTION
## Description
update readme with bump version rules.

It will be nice to set our MAJOR Repos to use landr linting and formating packages like that `1.X` so we do not have to update them all the time. But in order to do that we need to agree in a set of rules, And we will have to manually update the package only in certains situations.

**Open for Feedback**

## Checklist

- [ ] ~Updated the version number in the `package.json`~
- [ ] ~Test any new configuration on a repo using [`npm link`](https://docs.npmjs.com/cli/link)~
